### PR TITLE
Stricter type checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,7 +25,8 @@ Dockerfile*
 
 # OS
 .DS_Store
-Thumbs.db 
+Thumbs.db
 
 
 local-development/
+tsconfig.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "printWidth": 80
-}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "winston": "^3.8.2",
     "zod": "^3.24.1"
   },
+  "prettier": {
+    "singleQuote": true,
+    "printWidth": 80
+  },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/pg": "^8.6.6",

--- a/src/common/ambar/AmbarAuthMiddleware.ts
+++ b/src/common/ambar/AmbarAuthMiddleware.ts
@@ -25,7 +25,7 @@ export const AmbarAuthMiddleware = (
   }
 
   try {
-    const base64Credentials = authHeader.split(' ')[1];
+    const base64Credentials = authHeader.split(' ')[1] || '';
     const credentials = Buffer.from(base64Credentials, 'base64').toString(
       'utf8',
     );

--- a/src/common/ambar/AmbarAuthMiddleware.ts
+++ b/src/common/ambar/AmbarAuthMiddleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
-const VALID_USERNAME = process.env.AMBAR_HTTP_USERNAME;
-const VALID_PASSWORD = process.env.AMBAR_HTTP_PASSWORD;
+const VALID_USERNAME = process.env['AMBAR_HTTP_USERNAME'];
+const VALID_PASSWORD = process.env['AMBAR_HTTP_PASSWORD'];
 
 if (!VALID_USERNAME || !VALID_PASSWORD) {
   throw new Error(

--- a/src/common/ambar/AmbarAuthMiddleware.ts
+++ b/src/common/ambar/AmbarAuthMiddleware.ts
@@ -32,11 +32,11 @@ export const AmbarAuthMiddleware = (
     const [username, password] = credentials.split(':');
 
     if (username === VALID_USERNAME && password === VALID_PASSWORD) {
-      next();
+      return next();
     } else {
-      res.status(401).json({ error: 'Invalid credentials' });
+      return res.status(401).json({ error: 'Invalid credentials' });
     }
   } catch (error) {
-    res.status(401).json({ error: 'Invalid authentication format' });
+    return res.status(401).json({ error: 'Invalid authentication format' });
   }
 };

--- a/src/common/eventStore/PostgresTransactionalEventStore.ts
+++ b/src/common/eventStore/PostgresTransactionalEventStore.ts
@@ -60,16 +60,15 @@ export class PostgresTransactionalEventStore {
       this.deserializer.deserialize(e),
     );
 
-    if (events.length === 0) {
+    const firstEvent: Event | undefined = events[0];
+    if (firstEvent == undefined) {
       throw new Error(`No events found for aggregateId: ${aggregateId}`);
     }
-
-    const creationEvent = events[0];
-    const transformationEvents = events.slice(1);
-
+    const creationEvent: Event = firstEvent;
     if (!this.isCreationEventForAggregate<T>(creationEvent)) {
       throw new Error('First event is not a creation event');
     }
+    const transformationEvents = events.slice(1);
 
     let aggregate = creationEvent.createAggregate();
     let eventIdOfLastEvent = creationEvent.eventId;
@@ -147,10 +146,10 @@ export class PostgresTransactionalEventStore {
     if (!this.connection) throw new Error('No active connection');
 
     const sql = `
-            SELECT id, event_id, aggregate_id, causation_id, correlation_id, 
+            SELECT id, event_id, aggregate_id, causation_id, correlation_id,
                    aggregate_version, json_payload, json_metadata, recorded_on, event_name
             FROM ${this.eventStoreTable}
-            WHERE aggregate_id = $1 
+            WHERE aggregate_id = $1
             ORDER BY aggregate_version ASC
         `;
 
@@ -171,7 +170,7 @@ export class PostgresTransactionalEventStore {
 
     const sql = `
             INSERT INTO ${this.eventStoreTable} (
-                event_id, aggregate_id, causation_id, correlation_id, 
+                event_id, aggregate_id, causation_id, correlation_id,
                 aggregate_version, json_payload, json_metadata, recorded_on, event_name
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         `;
@@ -203,7 +202,7 @@ export class PostgresTransactionalEventStore {
     if (!this.connection) throw new Error('No active connection');
 
     const sql = `
-            SELECT id, event_id, aggregate_id, causation_id, correlation_id, 
+            SELECT id, event_id, aggregate_id, causation_id, correlation_id,
                    aggregate_version, json_payload, json_metadata, recorded_on, event_name
             FROM ${this.eventStoreTable}
             WHERE event_id = $1

--- a/src/common/projection/MongoTransactionalProjectionOperator.ts
+++ b/src/common/projection/MongoTransactionalProjectionOperator.ts
@@ -1,6 +1,5 @@
 import {
   ClientSession,
-  MongoClient,
   Filter,
   FindOptions,
   Document,

--- a/src/common/serializedEvent/Serializer.ts
+++ b/src/common/serializedEvent/Serializer.ts
@@ -34,14 +34,14 @@ export class Serializer {
     const payload: Record<string, any> = {};
 
     if (event instanceof ApplicationSubmitted) {
-      payload.firstName = event.firstName;
-      payload.lastName = event.lastName;
-      payload.favoriteCuisine = event.favoriteCuisine;
-      payload.yearsOfProfessionalExperience =
+      payload['firstName'] = event.firstName;
+      payload['lastName'] = event.lastName;
+      payload['favoriteCuisine'] = event.favoriteCuisine;
+      payload['yearsOfProfessionalExperience'] =
         event.yearsOfProfessionalExperience;
-      payload.numberOfCookingBooksRead = event.numberOfCookingBooksRead;
+      payload['numberOfCookingBooksRead'] = event.numberOfCookingBooksRead;
     } else if (event instanceof ApplicationEvaluated) {
-      payload.evaluationOutcome = event.evaluationOutcome;
+      payload['evaluationOutcome'] = event.evaluationOutcome;
     }
 
     return JSON.stringify(payload);

--- a/src/common/util/IdGenerator.ts
+++ b/src/common/util/IdGenerator.ts
@@ -26,12 +26,20 @@ export class IdGenerator {
     const chars = new Array(this.ID_LENGTH);
 
     for (let i = 0; i < this.ID_LENGTH; i++) {
-      const randomByte = randomBytes(1)[0];
+      const byte = randomByte();
       chars[i] = this.ALPHANUMERIC_CHARACTERS.charAt(
-        randomByte % this.ALPHANUMERIC_CHARACTERS.length,
+        byte % this.ALPHANUMERIC_CHARACTERS.length,
       );
     }
 
     return chars.join('');
   }
+}
+
+function randomByte(): number {
+  const byte = randomBytes(1)[0];
+  if (byte == undefined) {
+    throw new Error('No byte returned by randomBytes');
+  }
+  return byte;
 }

--- a/src/domain/cookingClub/membership/projection/membersByCuisine/CuisineRepository.ts
+++ b/src/domain/cookingClub/membership/projection/membersByCuisine/CuisineRepository.ts
@@ -25,7 +25,7 @@ export class CuisineRepository {
       this.collectionName,
       { _id },
     );
-    return results.length > 0 ? results[0] : null;
+    return results[0] || null;
   }
 
   async findAll(): Promise<Cuisine[]> {

--- a/src/domain/cookingClub/membership/projection/membersByCuisine/MembershipApplicationRepository.ts
+++ b/src/domain/cookingClub/membership/projection/membersByCuisine/MembershipApplicationRepository.ts
@@ -26,6 +26,6 @@ export class MembershipApplicationRepository {
       this.collectionName,
       { _id },
     );
-    return results.length > 0 ? results[0] : null;
+    return results[0] || null;
   }
 }

--- a/src/domain/cookingClub/membership/query/membersByCuisine/MembersByCuisineQueryController.ts
+++ b/src/domain/cookingClub/membership/query/membersByCuisine/MembersByCuisineQueryController.ts
@@ -25,7 +25,7 @@ export class MembersByCuisineQueryController extends QueryController {
     this.router.post('/members-by-cuisine', this.membersByCuisine.bind(this));
   }
 
-  async membersByCuisine(req: Request, res: Response): Promise<void> {
+  async membersByCuisine(_req: Request, res: Response): Promise<void> {
     const query = new MembersByCuisineQuery();
 
     const result = await this.processQuery(

--- a/src/domain/cookingClub/membership/query/membersByCuisine/MembersByCuisineQueryHandler.ts
+++ b/src/domain/cookingClub/membership/query/membersByCuisine/MembersByCuisineQueryHandler.ts
@@ -20,7 +20,7 @@ export class MembersByCuisineQueryHandler extends QueryHandler {
     this.cuisineRepository = cuisineRepository;
   }
 
-  async handleQuery(query: MembersByCuisineQuery): Promise<Cuisine[]> {
+  async handleQuery(_query: MembersByCuisineQuery): Promise<Cuisine[]> {
     return await this.cuisineRepository.findAll();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,16 +51,16 @@ app.use(
     return controller.router(req, res, next);
   },
 );
-app.get('/docker_healthcheck', (req, res) => res.send('OK'));
-app.get('/', (req, res) => res.send('OK'));
+app.get('/docker_healthcheck', (_req, res) => res.send('OK'));
+app.get('/', (_req, res) => res.send('OK'));
 
 // Error handling middleware
 app.use(
   (
     err: Error,
-    req: express.Request,
+    _req: express.Request,
     res: express.Response,
-    next: express.NextFunction,
+    _next: express.NextFunction,
   ) => {
     log.error('Unhandled error:', err);
     res.status(500).json({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "nodenext",
     "outDir": "dist",
     "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+    },
+
     "strict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitAny": true,
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
     "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,26 +3,28 @@
     "target": "ES2020",
     "module": "nodenext",
     "outDir": "dist",
-    "rootDir": "src",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
     },
 
-    "strict": true,
-    "esModuleInterop": true,
+    "strict": true,                               // a bunch of stronger type guarantees.
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "skipLibCheck": true,
-    "noImplicitAny": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
+    "skipLibCheck": false,                        // don't typecheck library files that weren't imported.
+    "noUnusedLocals": true,                       // every local variable must be used.
+    "noUnusedParameters": true,                   // every named parameter that doesn't start with '_' must be used.
+    "exactOptionalPropertyTypes": true,           // optional values cannot be set to undefined. They are either missing or present.
+    "noImplicitReturns": true,                    // every path must have a 'return'.
+    "noFallthroughCasesInSwitch": true,           // every case needs a 'break' or 'return'.
+    "noUncheckedIndexedAccess": true,             // the type of index access is always "T | undefined" and you much check for the undefined.
+    "noImplicitOverride": true,                   // must use 'override' keyword for method overrides.
+    "noPropertyAccessFromIndexSignature": true,   // if a property isn't declared in a type, you have to use square brackets to access it.
+    "isolatedModules": true,                      // more predictable behaviour with edge-cases of module imports.
+    "moduleDetection": "force",                   // every non declaration file is a module.
+    "allowUnusedLabels": false,                   // declared labels must be used.
+    "allowUnreachableCode": false,                // unreachable code is an error.
+    "checkJs": true,                              // type-check JS files.
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
     "noImplicitAny": true,
+    "noUnusedLocals": true,
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR introduces no behaviour changes.
Tightening the type-checking rules required some lines to be refactored to ensure type-safety but no logic was changed.
Each property that required a refactoring is in an individual commit with the required refactoring.

Also sneaked-in moving`.prettierrc` to `package.json` to have one file less at the top level.